### PR TITLE
fix go mod vendor missed .h files

### DIFF
--- a/include/placeholder.go
+++ b/include/placeholder.go
@@ -1,0 +1,3 @@
+// this file placed here to ensure go mod vendor copy all .h files, see https://github.com/golang/go/issues/26366
+
+package include

--- a/sciter.go
+++ b/sciter.go
@@ -41,6 +41,8 @@ import (
 	"runtime"
 	"strings"
 	"unsafe"
+
+	_ "github.com/sciter-sdk/go-sciter/include"
 )
 
 type Sciter struct {


### PR DESCRIPTION
Since go mod vendor will ignore all .h files in `include`, I have to ensure `include` as an empty go mod.